### PR TITLE
Fixed typo

### DIFF
--- a/units/faeries/Fire_Faerie.cfg
+++ b/units/faeries/Fire_Faerie.cfg
@@ -19,7 +19,7 @@
     advances_to=Faerie Dryad,Faerie Spirit
     cost=42
     usage=archer
-    description= _ "Faeries are rarely seen on a battlefield, as they are usually pacific creatures when not disturbed. And they are rarely disturbed, as most races know already what the consequences can be if they dare defy a faerie, and thus they choose to respect them and their homes. However, it is said that in times of war and great need they can become powerful allies to those who protect nature as much as they do. And the best race for that purpose are the forest elves.
+    description= _ "Faeries are rarely seen on a battlefield, as they are usually pacifistic creatures when not disturbed. And they are rarely disturbed, as most races know already what the consequences can be if they dare defy a faerie, and thus they choose to respect them and their homes. However, it is said that in times of war and great need they can become powerful allies to those who protect nature as much as they do. And the best race for that purpose are the forest elves.
 
 The most experienced faeries have developed a fearsome mastery of the fire element, which they can use to throw powerful fireballs to their opponents at long range, or to burn them at close range with a single touch of their hands. It is said that their very bodies start to burn, eventually leading them to become non-corporeal spirits of nature made of pure fire."+{SPECIAL_NOTES}+{SPECIAL_NOTES_MAGICAL}
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}


### PR DESCRIPTION
I would also say 

> to throw fireballs _at_ their opponents.

Didn‘t make that change though.